### PR TITLE
Complete Tetris AI GitHub Issue #2

### DIFF
--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -535,7 +535,7 @@ export class TetrisGame {
     );
     const isMini =
       frontOccupied < 2 ||
-      (this.lastKick[0] !== 0 && this.lastKick[1] !== 0);
+      (this.lastKick[0] !== 0 || this.lastKick[1] !== 0);
     return { isTSpin: true, isMini };
   }
 


### PR DESCRIPTION
Change AND operator to OR in T-Spin Mini detection. According to Tetris Guideline, Mini designation should trigger with movement in either x OR y direction, not both.

Fixes #2